### PR TITLE
chore: test createRide

### DIFF
--- a/opinions.md
+++ b/opinions.md
@@ -34,18 +34,34 @@ One may argue that testing will be easier when DB is passed in as an object usin
 
 ## Test setup
 
-Mocha + NYC + Chai + Sinon = Jest
+Mocha + NYC + Chai + Chai-as-expected + Sinon = Jest
 
 If given the ability to choose the test runner, I will pretty much prefer Jest as it requires very little setup. Aside from that it has expect and code coverage out of the box. The cherry on top will be it's CLI which allows a developer to run various subset of tests, for instance:
 
 - only changed files since last commit
 - regex filter on files to run
 
+Considering that the tools doesn't have high cohesion with one another, it results in high setup cost, or fats, that is involved in writing test. This is one way to make developers hate to write tests.
+
+One such example is when doing basic stubbing, one has to:
+
+- setup chai
+- setup stub
+- teardown sinon sandbox
+
+If the developer forgets to run the test in describe scope, the one test file might affect the results of another test file.
+
 ## Automatic input validation message
 
 Looking at the endpoint we can see how verbose the validation can get. Using hapi's Joi framework for validation, we can simply create the schema for the object and allow the assert method to throw or the validator to return the error message.
 
 This is especially useful considering that developers tend to copy and paste error messages, as shown in the base code provided. These erroneous error message won't be as useful if they are not reflective of the problem at hand.
+
+## Inconsistent client-side data representation
+
+When POST-ing a ride information, the keys for the ride information is using underscores, when the server returns the value, it is using camelCase. This is an example of a poorly developed API. The API forms the contract between the frontend and backend and must be standardized before the first line of code is written on either ends. Again I've wrote about this in my blog on Agility Under Uncertainty.
+
+For this reason, I've changed all the representations to camelCase considering that the database is already storing it in camelCase and the frontend developer is likely a javascript developer as well (Python developers will likely prefer camel case on the other hand).
 
 ## SonarQube
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5201,6 +5201,12 @@
       "integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=",
       "dev": true
     },
+    "json-parse-better-errors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+      "dev": true
+    },
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -5269,6 +5275,26 @@
       "requires": {
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2"
+      }
+    },
+    "load-json-file": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+      "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^4.0.0",
+        "pify": "^3.0.0",
+        "strip-bom": "^3.0.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        }
       }
     },
     "locate-path": {
@@ -5384,6 +5410,12 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
+    },
+    "memorystream": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz",
+      "integrity": "sha1-htcJCzDORV1j+64S3aUaR93K+bI=",
+      "dev": true
     },
     "merge-descriptors": {
       "version": "1.0.1",
@@ -9744,6 +9776,23 @@
         "npm-normalize-package-bin": "^1.0.1"
       }
     },
+    "npm-run-all": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/npm-run-all/-/npm-run-all-4.1.5.tgz",
+      "integrity": "sha512-Oo82gJDAVcaMdi3nuoKFavkIHBRVqQ1qvMb+9LHk/cF4P6B2m8aP04hGf7oL6wZ9BuGwX1onlLhpuoofSyoQDQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.1",
+        "chalk": "^2.4.1",
+        "cross-spawn": "^6.0.5",
+        "memorystream": "^0.3.1",
+        "minimatch": "^3.0.4",
+        "pidtree": "^0.3.0",
+        "read-pkg": "^3.0.0",
+        "shell-quote": "^1.6.1",
+        "string.prototype.padend": "^3.0.0"
+      }
+    },
     "npmlog": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
@@ -10120,6 +10169,16 @@
         "callsites": "^3.0.0"
       }
     },
+    "parse-json": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+      "dev": true,
+      "requires": {
+        "error-ex": "^1.3.1",
+        "json-parse-better-errors": "^1.0.1"
+      }
+    },
     "parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -10167,6 +10226,23 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
     },
+    "path-type": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+      "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+      "dev": true,
+      "requires": {
+        "pify": "^3.0.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        }
+      }
+    },
     "pathval": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
@@ -10177,6 +10253,12 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.1.1.tgz",
       "integrity": "sha512-OYMyqkKzK7blWO/+XZYP6w8hH0LDvkBvdvKukti+7kqYFCiEAk+gI3DWnryapc0Dau05ugGTy0foQ6mqn4AHYA==",
+      "dev": true
+    },
+    "pidtree": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.3.1.tgz",
+      "integrity": "sha512-qQbW94hLHEqCg7nhby4yRC7G2+jYHY4Rguc2bjw7Uug4GIJuu1tvf2uHaZv5Q8zdt+WKJ6qK1FOI6amaWUo5FA==",
       "dev": true
     },
     "pify": {
@@ -10351,6 +10433,17 @@
           "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
           "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
         }
+      }
+    },
+    "read-pkg": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+      "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+      "dev": true,
+      "requires": {
+        "load-json-file": "^4.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^3.0.0"
       }
     },
     "readable-stream": {
@@ -10720,6 +10813,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+      "dev": true
+    },
+    "shell-quote": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.2.tgz",
+      "integrity": "sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==",
       "dev": true
     },
     "signal-exit": {
@@ -11100,6 +11199,16 @@
         "code-point-at": "^1.0.0",
         "is-fullwidth-code-point": "^1.0.0",
         "strip-ansi": "^3.0.0"
+      }
+    },
+    "string.prototype.padend": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.padend/-/string.prototype.padend-3.1.0.tgz",
+      "integrity": "sha512-3aIv8Ffdp8EZj8iLwREGpQaUZiPyrWrpzMBHvkiSW/bK/EGve9np07Vwy7IJ5waydpGXzQZu/F8Oze2/IWkBaA==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.1"
       }
     },
     "string.prototype.trimleft": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "lint": "eslint . --ext js,ts,tsx",
     "lint:fix": "npm run lint -- --fix",
     "build": "tsc --emitDeclarationOnly && babel src -d dist --ignore src/**/*.spec.ts,src/**/*.test.ts -x .js,.ts,.tsx",
-    "pre-push": "npm run lint && npm run test && npm run test:integration"
+    "pre-push": "npm-run-all -p lint test test:integration"
   },
   "types": "dist/ts",
   "dependencies": {
@@ -67,6 +67,7 @@
     "mocha": "7.1.2",
     "nodemon": "2.0.4",
     "npm": "6.14.5",
+    "npm-run-all": "4.1.5",
     "nyc": "15.0.1",
     "prettier": "1.19.1",
     "sinon": "9.0.2",

--- a/src/database/database.ts
+++ b/src/database/database.ts
@@ -20,7 +20,7 @@ const DATABASE_SCHEMA = `
 
 const serialize = (): Promise<void> => new Promise(resolve => db.serialize(resolve));
 
-export const all = (queryString: string, params: any = []): Promise<any> => {
+export function all<T>(queryString: string, params: any = []): Promise<T> {
   return new Promise((resolve, reject) =>
     db.all(queryString, params, (error: Error, rows: any) => {
       if (error) {
@@ -30,7 +30,7 @@ export const all = (queryString: string, params: any = []): Promise<any> => {
       resolve(rows);
     })
   );
-};
+}
 
 export const run = (queryString: string, params: any = []): Promise<RunResult> => {
   return new Promise((resolve, reject) =>

--- a/src/handlers/createRide/createRide.test.ts
+++ b/src/handlers/createRide/createRide.test.ts
@@ -1,0 +1,44 @@
+import { expect, use } from "chai";
+import chaiAsPromised from "chai-as-promised";
+import sinon, { stub, SinonStubbedInstance } from "sinon";
+import * as database from "../../database";
+import { createRide } from "./createRide";
+
+use(chaiAsPromised);
+
+const validInput = {
+  startLat: "20",
+  endLat: "30",
+  startLong: "100",
+  endLong: "-110",
+  riderName: "foo",
+  driverName: "bar",
+  driverVehicle: "cow"
+};
+
+const rideEntry = {
+  ...validInput,
+  rideID: 1,
+  created: "2020-05-21 12:46:08"
+};
+
+describe("createRide", () => {
+  let db: SinonStubbedInstance<typeof database>;
+  before(() => {
+    db = stub(database);
+  });
+  after(() => {
+    sinon.restore();
+  });
+  it("should throw for incorrect ride inputs", async () => {
+    const res = createRide({ body: { ...validInput, startLat: 1337 } } as any);
+    await expect(res).rejected;
+  });
+
+  it("should insert the ride record and return it", async () => {
+    db.run.resolves({ lastID: 1337 } as any);
+    db.all.resolves([rideEntry]);
+    const res = await createRide({ body: validInput } as any);
+    expect(res).deep.equal([rideEntry]);
+  });
+});

--- a/src/handlers/createRide/createRide.ts
+++ b/src/handlers/createRide/createRide.ts
@@ -2,19 +2,18 @@ import { Request } from "express";
 import { handlerBoundary } from "../handlerBoundary";
 import { run, all } from "../../database";
 import { validateRideInput } from "./validate";
+import { RideEntry } from "../../types";
 
 export const createRide = async (req: Request) => {
-  const { start_lat, start_long, end_lat, end_long, rider_name, driver_name, driver_vehicle } = validateRideInput(
-    req.body
-  );
+  const { startLat, startLong, endLat, endLong, riderName, driverName, driverVehicle } = validateRideInput(req.body);
 
-  const values = [start_lat, start_long, end_lat, end_long, rider_name, driver_name, driver_vehicle];
+  const values = [startLat, startLong, endLat, endLong, riderName, driverName, driverVehicle];
 
   const { lastID } = await run(
     "INSERT INTO Rides(startLat, startLong, endLat, endLong, riderName, driverName, driverVehicle) VALUES (?, ?, ?, ?, ?, ?, ?)",
     values
   );
-  const rows = all("SELECT * FROM Rides WHERE rideID = ?", lastID);
+  const rows = all<RideEntry[]>("SELECT * FROM Rides WHERE rideID = ?", lastID);
   return rows;
 };
 

--- a/src/handlers/createRide/validate.test.ts
+++ b/src/handlers/createRide/validate.test.ts
@@ -2,84 +2,82 @@ import { expect } from "chai";
 import { validateRideInput } from "./validate";
 
 const validInput = {
-  start_lat: "20",
-  end_lat: "30",
-  start_long: "100",
-  end_long: "-110",
-  rider_name: "foo",
-  driver_name: "bar",
-  driver_vehicle: "cow"
+  startLat: "20",
+  endLat: "30",
+  startLong: "100",
+  endLong: "-110",
+  riderName: "foo",
+  driverName: "bar",
+  driverVehicle: "cow"
 };
 
 describe("validateRideInput", () => {
   it("should return the coerced values when validation passes", () => {
     const input = validateRideInput(validInput);
     expect(input).deep.equal({
-      start_lat: 20,
-      end_lat: 30,
-      start_long: 100,
-      end_long: -110,
-      rider_name: "foo",
-      driver_name: "bar",
-      driver_vehicle: "cow"
+      startLat: 20,
+      endLat: 30,
+      startLong: 100,
+      endLong: -110,
+      riderName: "foo",
+      driverName: "bar",
+      driverVehicle: "cow"
     });
   });
 
-  it("should throw when start_lat fails validation", () => {
-    expect(() => validateRideInput({ ...validInput, start_lat: "moo" })).throws(/"start_lat" must be a number/);
-    expect(() => validateRideInput({ ...validInput, start_lat: "91" })).throws(
-      /"start_lat" must be less than or equal to 90/
+  it("should throw when startLat fails validation", () => {
+    expect(() => validateRideInput({ ...validInput, startLat: "moo" })).throws(/"startLat" must be a number/);
+    expect(() => validateRideInput({ ...validInput, startLat: "91" })).throws(
+      /"startLat" must be less than or equal to 90/
     );
-    expect(() => validateRideInput({ ...validInput, start_lat: "-91" })).throws(
-      /"start_lat" must be larger than or equal to -90/
-    );
-  });
-
-  it("should throw when end_lat fails validation", () => {
-    expect(() => validateRideInput({ ...validInput, end_lat: "moo" })).throws(/"end_lat" must be a number/);
-    expect(() => validateRideInput({ ...validInput, end_lat: "91" })).throws(
-      /"end_lat" must be less than or equal to 90/
-    );
-    expect(() => validateRideInput({ ...validInput, end_lat: "-91" })).throws(
-      /"end_lat" must be larger than or equal to -90/
+    expect(() => validateRideInput({ ...validInput, startLat: "-91" })).throws(
+      /"startLat" must be larger than or equal to -90/
     );
   });
 
-  it("should throw when start_long fails validation", () => {
-    expect(() => validateRideInput({ ...validInput, start_long: "moo" })).throws(/"start_long" must be a number/);
-    expect(() => validateRideInput({ ...validInput, start_long: "181" })).throws(
-      /"start_long" must be less than or equal to 180/
+  it("should throw when endLat fails validation", () => {
+    expect(() => validateRideInput({ ...validInput, endLat: "moo" })).throws(/"endLat" must be a number/);
+    expect(() => validateRideInput({ ...validInput, endLat: "91" })).throws(
+      /"endLat" must be less than or equal to 90/
     );
-    expect(() => validateRideInput({ ...validInput, start_long: "-181" })).throws(
-      /"start_long" must be larger than or equal to -180/
-    );
-  });
-
-  it("should throw when end_long fails validation", () => {
-    expect(() => validateRideInput({ ...validInput, end_long: "moo" })).throws(/"end_long" must be a number/);
-    expect(() => validateRideInput({ ...validInput, end_long: "181" })).throws(
-      /"end_long" must be less than or equal to 180/
-    );
-    expect(() => validateRideInput({ ...validInput, end_long: "-181" })).throws(
-      /"end_long" must be larger than or equal to -180/
+    expect(() => validateRideInput({ ...validInput, endLat: "-91" })).throws(
+      /"endLat" must be larger than or equal to -90/
     );
   });
 
-  it("should throw when rider_name fails validation", () => {
-    expect(() => validateRideInput({ ...validInput, rider_name: "" })).throws(
-      /"rider_name" is not allowed to be empty/
+  it("should throw when startLong fails validation", () => {
+    expect(() => validateRideInput({ ...validInput, startLong: "moo" })).throws(/"startLong" must be a number/);
+    expect(() => validateRideInput({ ...validInput, startLong: "181" })).throws(
+      /"startLong" must be less than or equal to 180/
+    );
+    expect(() => validateRideInput({ ...validInput, startLong: "-181" })).throws(
+      /"startLong" must be larger than or equal to -180/
     );
   });
 
-  it("should throw when driver_name fails validation", () => {
-    expect(() => validateRideInput({ ...validInput, driver_name: "" })).throws(
-      /"driver_name" is not allowed to be empty/
+  it("should throw when endLong fails validation", () => {
+    expect(() => validateRideInput({ ...validInput, endLong: "moo" })).throws(/"endLong" must be a number/);
+    expect(() => validateRideInput({ ...validInput, endLong: "181" })).throws(
+      /"endLong" must be less than or equal to 180/
+    );
+    expect(() => validateRideInput({ ...validInput, endLong: "-181" })).throws(
+      /"endLong" must be larger than or equal to -180/
     );
   });
 
-  it("should throw when driver_vehicle fails validation", () => {
-    expect(() => validateRideInput({ ...validInput, driver_vehicle: "" })).throws(
-      /"driver_vehicle" is not allowed to be empty/
+  it("should throw when riderName fails validation", () => {
+    expect(() => validateRideInput({ ...validInput, riderName: "" })).throws(/"riderName" is not allowed to be empty/);
+  });
+
+  it("should throw when driverName fails validation", () => {
+    expect(() => validateRideInput({ ...validInput, driverName: "" })).throws(
+      /"driverName" is not allowed to be empty/
+    );
+  });
+
+  it("should throw when driverVehicle fails validation", () => {
+    expect(() => validateRideInput({ ...validInput, driverVehicle: "" })).throws(
+      /"driverVehicle" is not allowed to be empty/
     );
   });
 });

--- a/src/handlers/createRide/validate.ts
+++ b/src/handlers/createRide/validate.ts
@@ -1,39 +1,39 @@
 import joi from "@hapi/joi";
 import { throwValidationError } from "../../error";
-import { RideInput } from "../../types";
+import { Ride } from "../../types";
 
 interface RideInputRaw {
   [key: string]: string;
 }
 
 const rideSchema = joi.object({
-  start_lat: joi
+  startLat: joi
     .number()
     .min(-90)
     .max(90)
     .required(),
-  end_lat: joi
+  endLat: joi
     .number()
     .min(-90)
     .max(90)
     .required(),
-  start_long: joi
+  startLong: joi
     .number()
     .min(-180)
     .max(180)
     .required(),
-  end_long: joi
+  endLong: joi
     .number()
     .min(-180)
     .max(180)
     .required(),
-  rider_name: joi.string().required(),
-  driver_name: joi.string().required(),
-  driver_vehicle: joi.string().required()
+  riderName: joi.string().required(),
+  driverName: joi.string().required(),
+  driverVehicle: joi.string().required()
 });
 
 export const validateRideInput = (input: RideInputRaw) => {
   const { value, error } = rideSchema.validate(input);
   if (error) throwValidationError(error.message);
-  return value as RideInput;
+  return value as Ride;
 };

--- a/src/handlers/getRideById/getRideById.ts
+++ b/src/handlers/getRideById/getRideById.ts
@@ -2,10 +2,10 @@ import createHttpError from "http-errors";
 import { Request } from "express";
 import { handlerBoundary } from "../handlerBoundary";
 import { all } from "../../database";
-import { Ride } from "../../types";
+import { RideEntry } from "../../types";
 
 export const getRideById = async (req: Request) => {
-  const rides = await all<Ride[]>("SELECT * FROM Rides WHERE rideID=?", [req.params.id]);
+  const rides = await all<RideEntry[]>("SELECT * FROM Rides WHERE rideID=?", [req.params.id]);
   if (rides.length === 0)
     throw createHttpError(404, "Could not find any rides", { error_code: "RIDES_NOT_FOUND_ERROR" });
   return rides;

--- a/src/handlers/getRideById/getRideById.ts
+++ b/src/handlers/getRideById/getRideById.ts
@@ -2,9 +2,10 @@ import createHttpError from "http-errors";
 import { Request } from "express";
 import { handlerBoundary } from "../handlerBoundary";
 import { all } from "../../database";
+import { Ride } from "../../types";
 
 export const getRideById = async (req: Request) => {
-  const rides = await all("SELECT * FROM Rides WHERE rideID=?", [req.params.id]);
+  const rides = await all<Ride[]>("SELECT * FROM Rides WHERE rideID=?", [req.params.id]);
   if (rides.length === 0)
     throw createHttpError(404, "Could not find any rides", { error_code: "RIDES_NOT_FOUND_ERROR" });
   return rides;

--- a/src/handlers/getRides/getRides.test.ts
+++ b/src/handlers/getRides/getRides.test.ts
@@ -1,15 +1,20 @@
 import { expect, use } from "chai";
 import chaiAsPromised from "chai-as-promised";
-import { stub } from "sinon";
+import sinon, { stub, SinonStub } from "sinon";
 import * as database from "../../database";
 import { getRides } from "./getRides";
 import rides from "../../../fixtures/rides.json";
 
 use(chaiAsPromised);
 
-const allStub = stub(database, "all");
-
 describe("getRides", () => {
+  let allStub: SinonStub<any>;
+  before(() => {
+    allStub = stub(database, "all");
+  });
+  after(() => {
+    sinon.restore();
+  });
   beforeEach(() => {
     allStub.reset();
   });

--- a/src/handlers/getRides/getRides.ts
+++ b/src/handlers/getRides/getRides.ts
@@ -2,6 +2,7 @@ import { Request } from "express";
 import createHttpError from "http-errors";
 import { handlerBoundary } from "../handlerBoundary";
 import { all } from "../../database";
+import { Ride } from "../../types";
 
 const PAGE_SIZE = 20;
 
@@ -10,7 +11,7 @@ export const getRides = async (request: Request) => {
     throw createHttpError(400, "page must be a number", { error_code: "VALIDATION_ERROR" });
   const page = Number(request.query.page) || 0;
   if (page < 0) throw createHttpError(400, "page must be >= 0", { error_code: "VALIDATION_ERROR" });
-  const rides = await all(`SELECT * FROM Rides LIMIT ${PAGE_SIZE} OFFSET ?`, [page * PAGE_SIZE]);
+  const rides = await all<Ride[]>(`SELECT * FROM Rides LIMIT ${PAGE_SIZE} OFFSET ?`, [page * PAGE_SIZE]);
   if (rides.length === 0)
     throw createHttpError(404, "Could not find any rides", { error_code: "RIDES_NOT_FOUND_ERROR" });
   return rides;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,9 +1,14 @@
-export interface RideInput {
-  start_lat: number;
-  end_lat: number;
-  start_long: number;
-  end_long: number;
-  rider_name: string;
-  driver_name: string;
-  driver_vehicle: string;
+export interface Ride {
+  startLat: number;
+  endLat: number;
+  startLong: number;
+  endLong: number;
+  riderName: string;
+  driverName: string;
+  driverVehicle: string;
+}
+
+export interface RideEntry extends Ride {
+  created: string;
+  rideID: number;
 }


### PR DESCRIPTION
- fixed inconsistency between client POST format and server return format, using camelcase as the standard
- upgrade pre-push to use npm-run-all because of parallel test support
- added generic types to `all` queries for the database to automatically type returned results